### PR TITLE
Use Common Namespace in Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Install this package into your shared project. There is no need to install it in
    xmlns="http://xamarin.com/schemas/2014/forms" 
    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
    xmlns:rainbows="clr-namespace:Xamarin.Forms.DebugRainbows;assembly=Xamarin.Forms.DebugRainbows" 
-   x:Class="SampleApp.MainPage">
+   x:Class="MyNamespace.MainPage">
              
   ...
              


### PR DESCRIPTION
I just realized I used two different namespaces in the XAML examples 
(Apologies for the follow-up PR!)